### PR TITLE
PeripheryPaymentsExtended#wrapETH

### DIFF
--- a/contracts/base/PeripheryPaymentsExtended.sol
+++ b/contracts/base/PeripheryPaymentsExtended.sol
@@ -13,6 +13,11 @@ abstract contract PeripheryPaymentsExtended is IPeripheryPaymentsExtended, Perip
     }
 
     /// @inheritdoc IPeripheryPaymentsExtended
+    function wrapETH(uint256 value) external payable override {
+        IWETH9(WETH9).deposit{value: value}();
+    }
+
+    /// @inheritdoc IPeripheryPaymentsExtended
     function sweepToken(address token, uint256 amountMinimum) external payable override {
         sweepToken(token, amountMinimum, msg.sender);
     }

--- a/contracts/interfaces/IPeripheryPaymentsExtended.sol
+++ b/contracts/interfaces/IPeripheryPaymentsExtended.sol
@@ -11,6 +11,11 @@ interface IPeripheryPaymentsExtended is IPeripheryPayments {
     /// @param amountMinimum The minimum amount of WETH9 to unwrap
     function unwrapWETH9(uint256 amountMinimum) external payable;
 
+    /// @notice Wraps the contract's ETH balance into WETH9
+    /// @dev The resulting WETH9 is custodied by the router, thus will require further distribution
+    /// @param value The amount of ETH to wrap
+    function wrapETH(uint256 value) external payable;
+
     /// @notice Transfers the full amount of a token held by this contract to msg.sender
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
     /// @param token The contract address of the token which will be transferred to msg.sender

--- a/test/PeripheryPaymentsExtended.spec.ts
+++ b/test/PeripheryPaymentsExtended.spec.ts
@@ -1,0 +1,50 @@
+import { Fixture } from 'ethereum-waffle'
+import { constants, Contract, ContractTransaction, Wallet } from 'ethers'
+import { waffle, ethers } from 'hardhat'
+import { IWETH9, MockTimeSwapRouter02 } from '../typechain'
+import completeFixture from './shared/completeFixture'
+import { expect } from './shared/expect'
+
+describe('PeripheryPaymentsExtended', function () {
+  let wallet: Wallet
+
+  const routerFixture: Fixture<{
+    weth9: IWETH9
+    router: MockTimeSwapRouter02
+  }> = async (wallets, provider) => {
+    const { weth9, router } = await completeFixture(wallets, provider)
+
+    return {
+      weth9,
+      router,
+    }
+  }
+
+  let router: MockTimeSwapRouter02
+  let weth9: IWETH9
+
+  let loadFixture: ReturnType<typeof waffle.createFixtureLoader>
+
+  before('create fixture loader', async () => {
+    ;[wallet] = await (ethers as any).getSigners()
+    loadFixture = waffle.createFixtureLoader([wallet])
+  })
+
+  beforeEach('load fixture', async () => {
+    ;({ weth9, router } = await loadFixture(routerFixture))
+  })
+
+  describe('wrapETH', () => {
+    it('increases router WETH9 balance by value amount', async () => {
+      const value = ethers.utils.parseEther('1')
+
+      const weth9BalancePrev = await weth9.balanceOf(router.address)
+      await router.wrapETH(value, { value })
+      const weth9BalanceCurrent = await weth9.balanceOf(router.address)
+
+      expect(weth9BalanceCurrent.sub(weth9BalancePrev)).to.equal(value)
+      expect(await weth9.balanceOf(wallet.address)).to.equal('0')
+      expect(await router.provider.getBalance(router.address)).to.equal('0')
+    })
+  })
+})

--- a/test/__snapshots__/SwapRouter.gas.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.gas.spec.ts.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175376`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175387`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `110484`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `110495`;
 
 exports[`SwapRouter gas tests #exactInput 0 -> 1 minimal 1`] = `98059`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127412`;
+exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127423`;
 
-exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `108808`;
+exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `108820`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `109885`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `109896`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `126813`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `126824`;
 
-exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `108209`;
+exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `108221`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169272`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169283`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `111674`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `111685`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128614`;
+exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128625`;
 
-exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `119675`;
+exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `119687`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `111829`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `111840`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `128769`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `128780`;
 
-exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `112617`;
+exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `112629`;

--- a/test/__snapshots__/SwapRouter.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter bytecode size 1`] = `19483`;
+exports[`SwapRouter bytecode size 1`] = `19659`;


### PR DESCRIPTION
needed for swapAndAdd, since opening position with WETH9 is simpler, esp since we'll likely need to swap with it beforehand.