### PR TITLE
add flag for having already paid

### DIFF
--- a/contracts/V2SwapRouter.sol
+++ b/contracts/V2SwapRouter.sol
@@ -45,9 +45,15 @@ abstract contract V2SwapRouter is IV2SwapRouter, ConstantState, ImmutableState, 
         uint256 amountIn,
         uint256 amountOutMin,
         address[] calldata path,
-        address to
+        address to,
+        bool hasAlreadyPaid
     ) external payable override returns (uint256 amountOut) {
-        pay(path[0], msg.sender, UniswapV2Library.pairFor(factoryV2, path[0], path[1]), amountIn);
+        pay(
+            path[0],
+            hasAlreadyPaid ? address(this) : msg.sender,
+            UniswapV2Library.pairFor(factoryV2, path[0], path[1]),
+            amountIn
+        );
 
         // find and replace to addresses
         if (to == MSG_SENDER) to = msg.sender;
@@ -66,12 +72,18 @@ abstract contract V2SwapRouter is IV2SwapRouter, ConstantState, ImmutableState, 
         uint256 amountOut,
         uint256 amountInMax,
         address[] calldata path,
-        address to
+        address to,
+        bool hasAlreadyPaid
     ) external payable override returns (uint256 amountIn) {
         amountIn = UniswapV2Library.getAmountsIn(factoryV2, amountOut, path)[0];
         require(amountIn <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
 
-        pay(path[0], msg.sender, UniswapV2Library.pairFor(factoryV2, path[0], path[1]), amountIn);
+        pay(
+            path[0],
+            hasAlreadyPaid ? address(this) : msg.sender,
+            UniswapV2Library.pairFor(factoryV2, path[0], path[1]),
+            amountIn
+        );
 
         // find and replace to addresses
         if (to == MSG_SENDER) to = msg.sender;

--- a/contracts/V2SwapRouter.sol
+++ b/contracts/V2SwapRouter.sol
@@ -6,19 +6,18 @@ import '@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
 import './interfaces/IV2SwapRouter.sol';
-import './base/ConstantState.sol';
 import './base/ImmutableState.sol';
 import './libraries/UniswapV2Library.sol';
 import './base/PeripheryPaymentsWithFeeExtended.sol';
 
 /// @title Uniswap V2 Swap Router
 /// @notice Router for stateless execution of swaps against Uniswap V2
-abstract contract V2SwapRouter is IV2SwapRouter, ConstantState, ImmutableState, PeripheryPaymentsWithFeeExtended {
+abstract contract V2SwapRouter is IV2SwapRouter, ImmutableState, PeripheryPaymentsWithFeeExtended {
     using LowGasSafeMath for uint256;
 
     // supports fee-on-transfer tokens
     // requires the initial amount to have already been sent to the first pair
-    function _swap(address[] memory path, address _to) private {
+    function _swap(address[] memory path, address recipient) private {
         for (uint256 i; i < path.length - 1; i++) {
             (address input, address output) = (path[i], path[i + 1]);
             (address token0, ) = UniswapV2Library.sortTokens(input, output);
@@ -35,60 +34,166 @@ abstract contract V2SwapRouter is IV2SwapRouter, ConstantState, ImmutableState, 
             }
             (uint256 amount0Out, uint256 amount1Out) =
                 input == token0 ? (uint256(0), amountOutput) : (amountOutput, uint256(0));
-            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factoryV2, output, path[i + 2]) : _to;
+            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factoryV2, output, path[i + 2]) : recipient;
             pair.swap(amount0Out, amount1Out, to, new bytes(0));
         }
     }
 
-    /// @inheritdoc IV2SwapRouter
     function swapExactTokensForTokens(
-        uint256 amountIn,
-        uint256 amountOutMin,
-        address[] calldata path,
-        address to,
+        ExactInputV2Params calldata params,
+        address recipient,
         bool hasAlreadyPaid
-    ) external payable override returns (uint256 amountOut) {
+    ) internal returns (uint256 amountOut) {
         pay(
-            path[0],
+            params.path[0],
             hasAlreadyPaid ? address(this) : msg.sender,
-            UniswapV2Library.pairFor(factoryV2, path[0], path[1]),
-            amountIn
+            UniswapV2Library.pairFor(factoryV2, params.path[0], params.path[1]),
+            params.amountIn
         );
 
-        // find and replace to addresses
-        if (to == MSG_SENDER) to = msg.sender;
-        else if (to == ADDRESS_THIS) to = address(this);
+        uint256 balanceBefore = IERC20(params.path[params.path.length - 1]).balanceOf(recipient);
 
-        uint256 balanceBefore = IERC20(path[path.length - 1]).balanceOf(to);
+        _swap(params.path, recipient);
 
-        _swap(path, to);
-
-        amountOut = IERC20(path[path.length - 1]).balanceOf(to).sub(balanceBefore);
-        require(amountOut >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        amountOut = IERC20(params.path[params.path.length - 1]).balanceOf(recipient).sub(balanceBefore);
+        require(amountOut >= params.amountOutMinimum, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
     }
 
     /// @inheritdoc IV2SwapRouter
+    function swapExactTokensForTokensToSelf(ExactInputV2Params calldata params)
+        external
+        payable
+        override
+        returns (uint256 amountOut)
+    {
+        return swapExactTokensForTokens(params, msg.sender, false);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapExactTokensForTokensToRouter(ExactInputV2Params calldata params)
+        external
+        payable
+        override
+        returns (uint256 amountOut)
+    {
+        return swapExactTokensForTokens(params, address(this), false);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapExactTokensForTokensToRecipient(ExactInputV2Params calldata params, address recipient)
+        external
+        payable
+        override
+        returns (uint256 amountOut)
+    {
+        return swapExactTokensForTokens(params, recipient, false);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapExactTokensForTokensToSelfHavingPaid(ExactInputV2Params calldata params)
+        external
+        payable
+        override
+        returns (uint256 amountOut)
+    {
+        return swapExactTokensForTokens(params, msg.sender, true);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapExactTokensForTokensToRouterHavingPaid(ExactInputV2Params calldata params)
+        external
+        payable
+        override
+        returns (uint256 amountOut)
+    {
+        return swapExactTokensForTokens(params, address(this), true);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapExactTokensForTokensToRecipientHavingPaid(ExactInputV2Params calldata params, address recipient)
+        external
+        payable
+        override
+        returns (uint256 amountOut)
+    {
+        return swapExactTokensForTokens(params, recipient, true);
+    }
+
     function swapTokensForExactTokens(
-        uint256 amountOut,
-        uint256 amountInMax,
-        address[] calldata path,
-        address to,
+        ExactOutputV2Params calldata params,
+        address recipient,
         bool hasAlreadyPaid
-    ) external payable override returns (uint256 amountIn) {
-        amountIn = UniswapV2Library.getAmountsIn(factoryV2, amountOut, path)[0];
-        require(amountIn <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
+    ) internal returns (uint256 amountIn) {
+        amountIn = UniswapV2Library.getAmountsIn(factoryV2, params.amountOut, params.path)[0];
+        require(amountIn <= params.amountInMaximum, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
 
         pay(
-            path[0],
+            params.path[0],
             hasAlreadyPaid ? address(this) : msg.sender,
-            UniswapV2Library.pairFor(factoryV2, path[0], path[1]),
+            UniswapV2Library.pairFor(factoryV2, params.path[0], params.path[1]),
             amountIn
         );
 
-        // find and replace to addresses
-        if (to == MSG_SENDER) to = msg.sender;
-        else if (to == ADDRESS_THIS) to = address(this);
+        _swap(params.path, recipient);
+    }
 
-        _swap(path, to);
+    /// @inheritdoc IV2SwapRouter
+    function swapTokensForExactTokensToSelf(ExactOutputV2Params calldata params)
+        external
+        payable
+        override
+        returns (uint256 amountIn)
+    {
+        return swapTokensForExactTokens(params, msg.sender, false);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapTokensForExactTokensToRouter(ExactOutputV2Params calldata params)
+        external
+        payable
+        override
+        returns (uint256 amountIn)
+    {
+        return swapTokensForExactTokens(params, address(this), false);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapTokensForExactTokensToRecipient(ExactOutputV2Params calldata params, address recipient)
+        external
+        payable
+        override
+        returns (uint256 amountIn)
+    {
+        return swapTokensForExactTokens(params, recipient, false);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapTokensForExactTokensToSelfHavingPaid(ExactOutputV2Params calldata params)
+        external
+        payable
+        override
+        returns (uint256 amountIn)
+    {
+        return swapTokensForExactTokens(params, msg.sender, true);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapTokensForExactTokensToRouterHavingPaid(ExactOutputV2Params calldata params)
+        external
+        payable
+        override
+        returns (uint256 amountIn)
+    {
+        return swapTokensForExactTokens(params, address(this), true);
+    }
+
+    /// @inheritdoc IV2SwapRouter
+    function swapTokensForExactTokensToRecipientHavingPaid(ExactOutputV2Params calldata params, address recipient)
+        external
+        payable
+        override
+        returns (uint256 amountIn)
+    {
+        return swapTokensForExactTokens(params, recipient, true);
     }
 }

--- a/contracts/V2SwapRouter.sol
+++ b/contracts/V2SwapRouter.sol
@@ -43,7 +43,7 @@ abstract contract V2SwapRouter is IV2SwapRouter, ImmutableState, PeripheryPaymen
         ExactInputV2Params calldata params,
         address recipient,
         bool hasAlreadyPaid
-    ) internal returns (uint256 amountOut) {
+    ) private returns (uint256 amountOut) {
         pay(
             params.path[0],
             hasAlreadyPaid ? address(this) : msg.sender,
@@ -123,7 +123,7 @@ abstract contract V2SwapRouter is IV2SwapRouter, ImmutableState, PeripheryPaymen
         ExactOutputV2Params calldata params,
         address recipient,
         bool hasAlreadyPaid
-    ) internal returns (uint256 amountIn) {
+    ) private returns (uint256 amountIn) {
         amountIn = UniswapV2Library.getAmountsIn(factoryV2, params.amountOut, params.path)[0];
         require(amountIn <= params.amountInMaximum, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
 

--- a/contracts/V2SwapRouter.sol
+++ b/contracts/V2SwapRouter.sol
@@ -43,7 +43,7 @@ abstract contract V2SwapRouter is IV2SwapRouter, ImmutableState, PeripheryPaymen
         ExactInputV2Params calldata params,
         address recipient,
         bool hasAlreadyPaid
-    ) private returns (uint256 amountOut) {
+    ) internal returns (uint256 amountOut) {
         pay(
             params.path[0],
             hasAlreadyPaid ? address(this) : msg.sender,
@@ -123,7 +123,7 @@ abstract contract V2SwapRouter is IV2SwapRouter, ImmutableState, PeripheryPaymen
         ExactOutputV2Params calldata params,
         address recipient,
         bool hasAlreadyPaid
-    ) private returns (uint256 amountIn) {
+    ) internal returns (uint256 amountIn) {
         amountIn = UniswapV2Library.getAmountsIn(factoryV2, params.amountOut, params.path)[0];
         require(amountIn <= params.amountInMaximum, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
 

--- a/contracts/V3SwapRouter.sol
+++ b/contracts/V3SwapRouter.sol
@@ -57,10 +57,7 @@ abstract contract V3SwapRouter is IV3SwapRouter, ConstantState, PeripheryPayment
                 : (tokenOut < tokenIn, uint256(amount1Delta));
 
         if (isExactInput) {
-            // we only find and replace for exact input, because for exact output the payer has to be explicitly passed
-            // furthermore, we only match for address(this) because in this context msg.sender is a pool not a swapper
-            address payer = data.payer == ADDRESS_THIS ? address(this) : data.payer;
-            pay(tokenIn, payer, msg.sender, amountToPay);
+            pay(tokenIn, data.payer, msg.sender, amountToPay);
         } else {
             // either initiate the next swap or pay
             if (data.path.hasMultiplePools()) {
@@ -114,14 +111,17 @@ abstract contract V3SwapRouter is IV3SwapRouter, ConstantState, PeripheryPayment
             params.amountIn,
             params.recipient,
             params.sqrtPriceLimitX96,
-            SwapCallbackData({path: abi.encodePacked(params.tokenIn, params.fee, params.tokenOut), payer: msg.sender})
+            SwapCallbackData({
+                path: abi.encodePacked(params.tokenIn, params.fee, params.tokenOut),
+                payer: params.hasAlreadyPaid ? address(this) : msg.sender
+            })
         );
         require(amountOut >= params.amountOutMinimum, 'Too little received');
     }
 
     /// @inheritdoc IV3SwapRouter
     function exactInput(ExactInputParams memory params) external payable override returns (uint256 amountOut) {
-        address payer = msg.sender; // msg.sender pays for the first hop
+        address payer = params.hasAlreadyPaid ? address(this) : msg.sender;
 
         while (true) {
             bool hasMultiplePools = params.path.hasMultiplePools();
@@ -139,7 +139,7 @@ abstract contract V3SwapRouter is IV3SwapRouter, ConstantState, PeripheryPayment
 
             // decide whether to continue or terminate
             if (hasMultiplePools) {
-                payer = ADDRESS_THIS; // at this point, the caller has paid
+                payer = address(this);
                 params.path = params.path.skipToken();
             } else {
                 amountOut = params.amountIn;
@@ -197,7 +197,10 @@ abstract contract V3SwapRouter is IV3SwapRouter, ConstantState, PeripheryPayment
             params.amountOut,
             params.recipient,
             params.sqrtPriceLimitX96,
-            SwapCallbackData({path: abi.encodePacked(params.tokenOut, params.fee, params.tokenIn), payer: msg.sender})
+            SwapCallbackData({
+                path: abi.encodePacked(params.tokenOut, params.fee, params.tokenIn),
+                payer: params.hasAlreadyPaid ? address(this) : msg.sender
+            })
         );
 
         require(amountIn <= params.amountInMaximum, 'Too much requested');
@@ -207,13 +210,11 @@ abstract contract V3SwapRouter is IV3SwapRouter, ConstantState, PeripheryPayment
 
     /// @inheritdoc IV3SwapRouter
     function exactOutput(ExactOutputParams calldata params) external payable override returns (uint256 amountIn) {
-        // it's okay that the payer is fixed to msg.sender here, as they're only paying for the "final" exact output
-        // swap, which happens first, and subsequent swaps are paid for within nested callback frames
         exactOutputInternal(
             params.amountOut,
             params.recipient,
             0,
-            SwapCallbackData({path: params.path, payer: msg.sender})
+            SwapCallbackData({path: params.path, payer: params.hasAlreadyPaid ? address(this) : msg.sender})
         );
 
         amountIn = amountInCached;

--- a/contracts/V3SwapRouter.sol
+++ b/contracts/V3SwapRouter.sol
@@ -62,7 +62,7 @@ abstract contract V3SwapRouter is IV3SwapRouter, ConstantState, PeripheryPayment
             // either initiate the next swap or pay
             if (data.path.hasMultiplePools()) {
                 data.path = data.path.skipToken();
-                exactOutputInternal(amountToPay, MSG_SENDER, 0, data);
+                exactOutputInternal(amountToPay, msg.sender, 0, data);
             } else {
                 amountInCached = amountToPay;
                 // note that because exact output swaps are executed in reverse order, tokenOut is actually tokenIn
@@ -129,7 +129,7 @@ abstract contract V3SwapRouter is IV3SwapRouter, ConstantState, PeripheryPayment
             // the outputs of prior swaps become the inputs to subsequent ones
             params.amountIn = exactInputInternal(
                 params.amountIn,
-                hasMultiplePools ? ADDRESS_THIS : params.recipient, // for intermediate swaps, this contract custodies
+                hasMultiplePools ? address(this) : params.recipient, // for intermediate swaps, this contract custodies
                 0,
                 SwapCallbackData({
                     path: params.path.getFirstPool(), // only the first pool in the path is necessary

--- a/contracts/interfaces/IV2SwapRouter.sol
+++ b/contracts/interfaces/IV2SwapRouter.sol
@@ -5,127 +5,33 @@ pragma abicoder v2;
 /// @title Router token swapping functionality
 /// @notice Functions for swapping tokens via Uniswap V2
 interface IV2SwapRouter {
-    struct ExactInputV2Params {
-        uint256 amountIn;
-        uint256 amountOutMinimum;
-        address[] path;
-    }
-
-    struct ExactOutputV2Params {
-        uint256 amountOut;
-        uint256 amountInMaximum;
-        address[] path;
-    }
-
-    /// @notice Swaps an exact amount of one token for as much as possible of another,
-    /// sending the output to msg.sender
-    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
+    /// @notice Swaps `amountIn` of one token for as much as possible of another token
+    /// @param amountIn The amount of token to swap
+    /// @param amountOutMin The minimum amount of output that must be received
+    /// @param path The ordered list of tokens to swap through
+    /// @param to The recipient address
+    /// @param hasAlreadyPaid A flag to indicate that payment was already sent to the router
     /// @return amountOut The amount of the received token
-    function swapExactTokensForTokensToSelf(ExactInputV2Params calldata params)
-        external
-        payable
-        returns (uint256 amountOut);
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        bool hasAlreadyPaid
+    ) external payable returns (uint256 amountOut);
 
-    /// @notice Swaps an exact amount of one token for as much as possible of another,
-    /// sending the output to address(this)
-    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
-    /// @return amountOut The amount of the received token
-    function swapExactTokensForTokensToRouter(ExactInputV2Params calldata params)
-        external
-        payable
-        returns (uint256 amountOut);
-
-    /// @notice Swaps an exact amount of one token for as much as possible of another,
-    /// sending the output to `recipient`
-    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
-    /// @param recipient The recipient of the swap
-    /// @return amountOut The amount of the received token
-    function swapExactTokensForTokensToRecipient(ExactInputV2Params calldata params, address recipient)
-        external
-        payable
-        returns (uint256 amountOut);
-
-    /// @notice Swaps an exact amount of one token for as much as possible of another,
-    /// sending the output to msg.sender
-    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
-    /// @return amountOut The amount of the received token
-    function swapExactTokensForTokensToSelfHavingPaid(ExactInputV2Params calldata params)
-        external
-        payable
-        returns (uint256 amountOut);
-
-    /// @notice Swaps an exact amount of one token for as much as possible of another,
-    /// sending the output to address(this)
-    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
-    /// @return amountOut The amount of the received token
-    function swapExactTokensForTokensToRouterHavingPaid(ExactInputV2Params calldata params)
-        external
-        payable
-        returns (uint256 amountOut);
-
-    /// @notice Swaps an exact amount of one token for as much as possible of another,
-    /// sending the output to `recipient`
-    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
-    /// @param recipient The recipient of the swap
-    /// @return amountOut The amount of the received token
-    function swapExactTokensForTokensToRecipientHavingPaid(ExactInputV2Params calldata params, address recipient)
-        external
-        payable
-        returns (uint256 amountOut);
-
-    /// @notice Swaps as little as possible of one token for an exact amount of another token,
-    /// sending the output to msg.sender
-    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
+    /// @notice Swaps as little as possible of one token for an exact amount of another token
+    /// @param amountOut The amount of token to swap for
+    /// @param amountInMax The maximum amount of input that the caller will pay
+    /// @param path The ordered list of tokens to swap through
+    /// @param to The recipient address
+    /// @param hasAlreadyPaid A flag to indicate that payment was already sent to the router
     /// @return amountIn The amount of token to pay
-    function swapTokensForExactTokensToSelf(ExactOutputV2Params calldata params)
-        external
-        payable
-        returns (uint256 amountIn);
-
-    /// @notice Swaps as little as possible of one token for an exact amount of another token,
-    /// sending the output to address(this)
-    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
-    /// @return amountIn The amount of token to pay
-    function swapTokensForExactTokensToRouter(ExactOutputV2Params calldata params)
-        external
-        payable
-        returns (uint256 amountIn);
-
-    /// @notice Swaps as little as possible of one token for an exact amount of another token,
-    /// sending the output to `recipient`
-    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
-    /// @param recipient The recipient of the swap
-    /// @return amountIn The amount of token to pay
-    function swapTokensForExactTokensToRecipient(ExactOutputV2Params calldata params, address recipient)
-        external
-        payable
-        returns (uint256 amountIn);
-
-    /// @notice Swaps as little as possible of one token for an exact amount of another token,
-    /// sending the output to msg.sender
-    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
-    /// @return amountIn The amount of token to pay
-    function swapTokensForExactTokensToSelfHavingPaid(ExactOutputV2Params calldata params)
-        external
-        payable
-        returns (uint256 amountIn);
-
-    /// @notice Swaps as little as possible of one token for an exact amount of another token,
-    /// sending the output to address(this)
-    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
-    /// @return amountIn The amount of token to pay
-    function swapTokensForExactTokensToRouterHavingPaid(ExactOutputV2Params calldata params)
-        external
-        payable
-        returns (uint256 amountIn);
-
-    /// @notice Swaps as little as possible of one token for an exact amount of another token,
-    /// sending the output to `recipient`
-    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
-    /// @param recipient The recipient of the swap
-    /// @return amountIn The amount of token to pay
-    function swapTokensForExactTokensToRecipientHavingPaid(ExactOutputV2Params calldata params, address recipient)
-        external
-        payable
-        returns (uint256 amountIn);
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        bool hasAlreadyPaid
+    ) external payable returns (uint256 amountIn);
 }

--- a/contracts/interfaces/IV2SwapRouter.sol
+++ b/contracts/interfaces/IV2SwapRouter.sol
@@ -21,6 +21,8 @@ interface IV2SwapRouter {
     ) external payable returns (uint256 amountOut);
 
     /// @notice Swaps as little as possible of one token for an exact amount of another token
+    /// @dev If hasAlreadyPaid is true, callers should be sure to retrieve any excess tokens
+    /// that may remain in the router after the swap.
     /// @param amountOut The amount of token to swap for
     /// @param amountInMax The maximum amount of input that the caller will pay
     /// @param path The ordered list of tokens to swap through

--- a/contracts/interfaces/IV2SwapRouter.sol
+++ b/contracts/interfaces/IV2SwapRouter.sol
@@ -5,33 +5,127 @@ pragma abicoder v2;
 /// @title Router token swapping functionality
 /// @notice Functions for swapping tokens via Uniswap V2
 interface IV2SwapRouter {
-    /// @notice Swaps `amountIn` of one token for as much as possible of another token
-    /// @param amountIn The amount of token to swap
-    /// @param amountOutMin The minimum amount of output that must be received
-    /// @param path The ordered list of tokens to swap through
-    /// @param to The recipient address
-    /// @param hasAlreadyPaid A flag to indicate that payment was already sent to the router
-    /// @return amountOut The amount of the received token
-    function swapExactTokensForTokens(
-        uint256 amountIn,
-        uint256 amountOutMin,
-        address[] calldata path,
-        address to,
-        bool hasAlreadyPaid
-    ) external payable returns (uint256 amountOut);
+    struct ExactInputV2Params {
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        address[] path;
+    }
 
-    /// @notice Swaps as little as possible of one token for an exact amount of another token
-    /// @param amountOut The amount of token to swap for
-    /// @param amountInMax The maximum amount of input that the caller will pay
-    /// @param path The ordered list of tokens to swap through
-    /// @param to The recipient address
-    /// @param hasAlreadyPaid A flag to indicate that payment was already sent to the router
+    struct ExactOutputV2Params {
+        uint256 amountOut;
+        uint256 amountInMaximum;
+        address[] path;
+    }
+
+    /// @notice Swaps an exact amount of one token for as much as possible of another,
+    /// sending the output to msg.sender
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
+    /// @return amountOut The amount of the received token
+    function swapExactTokensForTokensToSelf(ExactInputV2Params calldata params)
+        external
+        payable
+        returns (uint256 amountOut);
+
+    /// @notice Swaps an exact amount of one token for as much as possible of another,
+    /// sending the output to address(this)
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
+    /// @return amountOut The amount of the received token
+    function swapExactTokensForTokensToRouter(ExactInputV2Params calldata params)
+        external
+        payable
+        returns (uint256 amountOut);
+
+    /// @notice Swaps an exact amount of one token for as much as possible of another,
+    /// sending the output to `recipient`
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
+    /// @param recipient The recipient of the swap
+    /// @return amountOut The amount of the received token
+    function swapExactTokensForTokensToRecipient(ExactInputV2Params calldata params, address recipient)
+        external
+        payable
+        returns (uint256 amountOut);
+
+    /// @notice Swaps an exact amount of one token for as much as possible of another,
+    /// sending the output to msg.sender
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
+    /// @return amountOut The amount of the received token
+    function swapExactTokensForTokensToSelfHavingPaid(ExactInputV2Params calldata params)
+        external
+        payable
+        returns (uint256 amountOut);
+
+    /// @notice Swaps an exact amount of one token for as much as possible of another,
+    /// sending the output to address(this)
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
+    /// @return amountOut The amount of the received token
+    function swapExactTokensForTokensToRouterHavingPaid(ExactInputV2Params calldata params)
+        external
+        payable
+        returns (uint256 amountOut);
+
+    /// @notice Swaps an exact amount of one token for as much as possible of another,
+    /// sending the output to `recipient`
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputV2Params` in calldata
+    /// @param recipient The recipient of the swap
+    /// @return amountOut The amount of the received token
+    function swapExactTokensForTokensToRecipientHavingPaid(ExactInputV2Params calldata params, address recipient)
+        external
+        payable
+        returns (uint256 amountOut);
+
+    /// @notice Swaps as little as possible of one token for an exact amount of another token,
+    /// sending the output to msg.sender
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
     /// @return amountIn The amount of token to pay
-    function swapTokensForExactTokens(
-        uint256 amountOut,
-        uint256 amountInMax,
-        address[] calldata path,
-        address to,
-        bool hasAlreadyPaid
-    ) external payable returns (uint256 amountIn);
+    function swapTokensForExactTokensToSelf(ExactOutputV2Params calldata params)
+        external
+        payable
+        returns (uint256 amountIn);
+
+    /// @notice Swaps as little as possible of one token for an exact amount of another token,
+    /// sending the output to address(this)
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
+    /// @return amountIn The amount of token to pay
+    function swapTokensForExactTokensToRouter(ExactOutputV2Params calldata params)
+        external
+        payable
+        returns (uint256 amountIn);
+
+    /// @notice Swaps as little as possible of one token for an exact amount of another token,
+    /// sending the output to `recipient`
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
+    /// @param recipient The recipient of the swap
+    /// @return amountIn The amount of token to pay
+    function swapTokensForExactTokensToRecipient(ExactOutputV2Params calldata params, address recipient)
+        external
+        payable
+        returns (uint256 amountIn);
+
+    /// @notice Swaps as little as possible of one token for an exact amount of another token,
+    /// sending the output to msg.sender
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
+    /// @return amountIn The amount of token to pay
+    function swapTokensForExactTokensToSelfHavingPaid(ExactOutputV2Params calldata params)
+        external
+        payable
+        returns (uint256 amountIn);
+
+    /// @notice Swaps as little as possible of one token for an exact amount of another token,
+    /// sending the output to address(this)
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
+    /// @return amountIn The amount of token to pay
+    function swapTokensForExactTokensToRouterHavingPaid(ExactOutputV2Params calldata params)
+        external
+        payable
+        returns (uint256 amountIn);
+
+    /// @notice Swaps as little as possible of one token for an exact amount of another token,
+    /// sending the output to `recipient`
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputV2Params` in calldata
+    /// @param recipient The recipient of the swap
+    /// @return amountIn The amount of token to pay
+    function swapTokensForExactTokensToRecipientHavingPaid(ExactOutputV2Params calldata params, address recipient)
+        external
+        payable
+        returns (uint256 amountIn);
 }

--- a/contracts/interfaces/IV2SwapRouter.sol
+++ b/contracts/interfaces/IV2SwapRouter.sol
@@ -10,12 +10,14 @@ interface IV2SwapRouter {
     /// @param amountOutMin The minimum amount of output that must be received
     /// @param path The ordered list of tokens to swap through
     /// @param to The recipient address
+    /// @param hasAlreadyPaid A flag to indicate that payment was already sent to the router
     /// @return amountOut The amount of the received token
     function swapExactTokensForTokens(
         uint256 amountIn,
         uint256 amountOutMin,
         address[] calldata path,
-        address to
+        address to,
+        bool hasAlreadyPaid
     ) external payable returns (uint256 amountOut);
 
     /// @notice Swaps as little as possible of one token for an exact amount of another token
@@ -23,11 +25,13 @@ interface IV2SwapRouter {
     /// @param amountInMax The maximum amount of input that the caller will pay
     /// @param path The ordered list of tokens to swap through
     /// @param to The recipient address
+    /// @param hasAlreadyPaid A flag to indicate that payment was already sent to the router
     /// @return amountIn The amount of token to pay
     function swapTokensForExactTokens(
         uint256 amountOut,
         uint256 amountInMax,
         address[] calldata path,
-        address to
+        address to,
+        bool hasAlreadyPaid
     ) external payable returns (uint256 amountIn);
 }

--- a/contracts/interfaces/IV3SwapRouter.sol
+++ b/contracts/interfaces/IV3SwapRouter.sol
@@ -48,6 +48,8 @@ interface IV3SwapRouter is IUniswapV3SwapCallback {
     }
 
     /// @notice Swaps as little as possible of one token for `amountOut` of another token
+    /// @dev If params.hasAlreadyPaid is true, callers should be sure to retrieve any excess tokens
+    /// that may remain in the router after the swap.
     /// @param params The parameters necessary for the swap, encoded as `ExactOutputSingleParams` in calldata
     /// @return amountIn The amount of the input token
     function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
@@ -61,6 +63,8 @@ interface IV3SwapRouter is IUniswapV3SwapCallback {
     }
 
     /// @notice Swaps as little as possible of one token for `amountOut` of another along the specified path (reversed)
+    /// @dev If params.hasAlreadyPaid is true, callers should be sure to retrieve any excess tokens
+    /// that may remain in the router after the swap.
     /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactOutputParams` in calldata
     /// @return amountIn The amount of the input token
     function exactOutput(ExactOutputParams calldata params) external payable returns (uint256 amountIn);

--- a/contracts/interfaces/IV3SwapRouter.sol
+++ b/contracts/interfaces/IV3SwapRouter.sol
@@ -15,6 +15,7 @@ interface IV3SwapRouter is IUniswapV3SwapCallback {
         uint256 amountIn;
         uint256 amountOutMinimum;
         uint160 sqrtPriceLimitX96;
+        bool hasAlreadyPaid;
     }
 
     /// @notice Swaps `amountIn` of one token for as much as possible of another token
@@ -27,6 +28,7 @@ interface IV3SwapRouter is IUniswapV3SwapCallback {
         address recipient;
         uint256 amountIn;
         uint256 amountOutMinimum;
+        bool hasAlreadyPaid;
     }
 
     /// @notice Swaps `amountIn` of one token for as much as possible of another along the specified path
@@ -42,6 +44,7 @@ interface IV3SwapRouter is IUniswapV3SwapCallback {
         uint256 amountOut;
         uint256 amountInMaximum;
         uint160 sqrtPriceLimitX96;
+        bool hasAlreadyPaid;
     }
 
     /// @notice Swaps as little as possible of one token for `amountOut` of another token
@@ -54,6 +57,7 @@ interface IV3SwapRouter is IUniswapV3SwapCallback {
         address recipient;
         uint256 amountOut;
         uint256 amountInMaximum;
+        bool hasAlreadyPaid;
     }
 
     /// @notice Swaps as little as possible of one token for `amountOut` of another along the specified path (reversed)

--- a/test/ApproveAndCall.spec.ts
+++ b/test/ApproveAndCall.spec.ts
@@ -1,6 +1,8 @@
+import { defaultAbiCoder } from '@ethersproject/abi'
 import { Fixture } from 'ethereum-waffle'
 import { constants, Contract, ContractTransaction, Wallet } from 'ethers'
-import { waffle, ethers } from 'hardhat'
+import { solidityPack } from 'ethers/lib/utils'
+import { ethers, waffle } from 'hardhat'
 import { MockTimeSwapRouter02, TestERC20 } from '../typechain'
 import completeFixture from './shared/completeFixture'
 import { FeeAmount, TICK_SPACINGS } from './shared/constants'
@@ -9,8 +11,6 @@ import { expandTo18Decimals } from './shared/expandTo18Decimals'
 import { expect } from './shared/expect'
 import { encodePath } from './shared/path'
 import { getMaxTick, getMinTick } from './shared/ticks'
-import { defaultAbiCoder } from '@ethersproject/abi'
-import { solidityPack } from 'ethers/lib/utils'
 
 const ADDRESS_THIS = '0x0000000000000000000000000000000000000001'
 
@@ -109,6 +109,7 @@ describe('ApproveAndCall', function () {
         recipient: ADDRESS_THIS, // have to send to the router, as it will be adding liquidity for the caller
         amountIn,
         amountOutMinimum,
+        hasAlreadyPaid: false,
       }
       // ensure that the swap fails if the limit is any tighter
       const amountOut = await router.connect(trader).callStatic.exactInput(params)

--- a/test/ApproveAndCall.spec.ts
+++ b/test/ApproveAndCall.spec.ts
@@ -5,14 +5,12 @@ import { solidityPack } from 'ethers/lib/utils'
 import { ethers, waffle } from 'hardhat'
 import { MockTimeSwapRouter02, TestERC20 } from '../typechain'
 import completeFixture from './shared/completeFixture'
-import { FeeAmount, TICK_SPACINGS } from './shared/constants'
+import { ADDRESS_THIS, FeeAmount, TICK_SPACINGS } from './shared/constants'
 import { encodePriceSqrt } from './shared/encodePriceSqrt'
 import { expandTo18Decimals } from './shared/expandTo18Decimals'
 import { expect } from './shared/expect'
 import { encodePath } from './shared/path'
 import { getMaxTick, getMinTick } from './shared/ticks'
-
-const ADDRESS_THIS = '0x0000000000000000000000000000000000000001'
 
 describe('ApproveAndCall', function () {
   this.timeout(40000)

--- a/test/SwapRouter.gas.spec.ts
+++ b/test/SwapRouter.gas.spec.ts
@@ -1,5 +1,8 @@
+import { defaultAbiCoder } from '@ethersproject/abi'
+import { abi as IUniswapV3PoolABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
 import { Fixture } from 'ethereum-waffle'
 import { BigNumber, constants, ContractTransaction, Wallet } from 'ethers'
+import { solidityPack } from 'ethers/lib/utils'
 import { ethers, waffle } from 'hardhat'
 import { IUniswapV3Pool, IWETH9, MockTimeSwapRouter02, TestERC20 } from '../typechain'
 import completeFixture from './shared/completeFixture'
@@ -10,10 +13,6 @@ import { expect } from './shared/expect'
 import { encodePath } from './shared/path'
 import snapshotGasCost from './shared/snapshotGasCost'
 import { getMaxTick, getMinTick } from './shared/ticks'
-import { defaultAbiCoder } from '@ethersproject/abi'
-
-import { abi as IUniswapV3PoolABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
-import { solidityPack } from 'ethers/lib/utils'
 
 describe('SwapRouter gas tests', function () {
   this.timeout(40000)
@@ -136,6 +135,7 @@ describe('SwapRouter gas tests', function () {
       recipient: outputIsWETH9 ? ADDRESS_THIS : MSG_SENDER,
       amountIn,
       amountOutMinimum: outputIsWETH9 ? 0 : amountOutMinimum, // save on calldata
+      hasAlreadyPaid: false,
     }
 
     const data = [router.interface.encodeFunctionData('exactInput', [params])]
@@ -166,6 +166,7 @@ describe('SwapRouter gas tests', function () {
       amountIn,
       amountOutMinimum: outputIsWETH9 ? 0 : amountOutMinimum, // save on calldata
       sqrtPriceLimitX96: sqrtPriceLimitX96 ?? 0,
+      hasAlreadyPaid: false,
     }
 
     const data = [router.interface.encodeFunctionData('exactInputSingle', [params])]
@@ -190,6 +191,7 @@ describe('SwapRouter gas tests', function () {
       recipient: outputIsWETH9 ? ADDRESS_THIS : MSG_SENDER,
       amountOut,
       amountInMaximum,
+      hasAlreadyPaid: false,
     }
 
     const data = [router.interface.encodeFunctionData('exactOutput', [params])]
@@ -224,6 +226,7 @@ describe('SwapRouter gas tests', function () {
       amountOut,
       amountInMaximum,
       sqrtPriceLimitX96: sqrtPriceLimitX96 ?? 0,
+      hasAlreadyPaid: false,
     }
 
     const data = [router.interface.encodeFunctionData('exactOutputSingle', [params])]

--- a/test/SwapRouter.spec.ts
+++ b/test/SwapRouter.spec.ts
@@ -75,6 +75,17 @@ describe('SwapRouter', function () {
     )
   }
 
+  function encodeSweep(token: string, amount: number, recipient: string) {
+    const functionSignature = 'sweepToken(address,uint256,address)'
+    return solidityPack(
+      ['bytes4', 'bytes'],
+      [
+        router.interface.getSighash(functionSignature),
+        defaultAbiCoder.encode(router.interface.functions[functionSignature].inputs, [token, amount, recipient]),
+      ]
+    )
+  }
+
   before('create fixture loader', async () => {
     ;[wallet, trader] = await (ethers as any).getSigners()
     loadFixture = waffle.createFixtureLoader([wallet, trader])
@@ -112,45 +123,39 @@ describe('SwapRouter', function () {
     expect(((await router.provider.getCode(router.address)).length - 2) / 2).to.matchSnapshot()
   })
 
-  describe('swaps - v3', () => {
-    const liquidity = 1000000
-    async function createPool(tokenAddressA: string, tokenAddressB: string) {
-      if (tokenAddressA.toLowerCase() > tokenAddressB.toLowerCase())
-        [tokenAddressA, tokenAddressB] = [tokenAddressB, tokenAddressA]
+  const liquidity = 1000000
+  async function createV3Pool(tokenAddressA: string, tokenAddressB: string) {
+    if (tokenAddressA.toLowerCase() > tokenAddressB.toLowerCase())
+      [tokenAddressA, tokenAddressB] = [tokenAddressB, tokenAddressA]
 
-      await nft.createAndInitializePoolIfNecessary(
-        tokenAddressA,
-        tokenAddressB,
-        FeeAmount.MEDIUM,
-        encodePriceSqrt(1, 1)
-      )
+    await nft.createAndInitializePoolIfNecessary(tokenAddressA, tokenAddressB, FeeAmount.MEDIUM, encodePriceSqrt(1, 1))
 
-      const liquidityParams = {
-        token0: tokenAddressA,
-        token1: tokenAddressB,
-        fee: FeeAmount.MEDIUM,
-        tickLower: getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
-        tickUpper: getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
-        recipient: wallet.address,
-        amount0Desired: 1000000,
-        amount1Desired: 1000000,
-        amount0Min: 0,
-        amount1Min: 0,
-        deadline: 2 ** 32,
-      }
-
-      return nft.mint(liquidityParams)
+    const liquidityParams = {
+      token0: tokenAddressA,
+      token1: tokenAddressB,
+      fee: FeeAmount.MEDIUM,
+      tickLower: getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
+      tickUpper: getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
+      recipient: wallet.address,
+      amount0Desired: 1000000,
+      amount1Desired: 1000000,
+      amount0Min: 0,
+      amount1Min: 0,
+      deadline: 2 ** 32,
     }
 
+    return nft.mint(liquidityParams)
+  }
+  describe('swaps - v3', () => {
     async function createPoolWETH9(tokenAddress: string) {
       await weth9.deposit({ value: liquidity })
       await weth9.approve(nft.address, constants.MaxUint256)
-      return createPool(weth9.address, tokenAddress)
+      return createV3Pool(weth9.address, tokenAddress)
     }
 
     beforeEach('create 0-1 and 1-2 pools', async () => {
-      await createPool(tokens[0].address, tokens[1].address)
-      await createPool(tokens[1].address, tokens[2].address)
+      await createV3Pool(tokens[0].address, tokens[1].address)
+      await createV3Pool(tokens[1].address, tokens[2].address)
     })
 
     describe('#exactInput', () => {
@@ -932,33 +937,31 @@ describe('SwapRouter', function () {
     })
   })
 
+  async function createV2Pool(tokenA: TestERC20, tokenB: TestERC20): Promise<IUniswapV2Pair> {
+    await factoryV2.createPair(tokenA.address, tokenB.address)
+
+    const pairAddress = await factoryV2.getPair(tokenA.address, tokenB.address)
+    const pair = new ethers.Contract(pairAddress, PAIR_V2_ABI, wallet) as IUniswapV2Pair
+
+    await tokenA.transfer(pair.address, liquidity)
+    await tokenB.transfer(pair.address, liquidity)
+
+    await pair.mint(wallet.address)
+
+    return pair
+  }
   describe('swaps - v2', () => {
     let pairs: IUniswapV2Pair[]
     let wethPairs: IUniswapV2Pair[]
 
-    const liquidity = 1000000
-    async function createPool(tokenA: TestERC20, tokenB: TestERC20): Promise<IUniswapV2Pair> {
-      await factoryV2.createPair(tokenA.address, tokenB.address)
-
-      const pairAddress = await factoryV2.getPair(tokenA.address, tokenB.address)
-      const pair = new ethers.Contract(pairAddress, PAIR_V2_ABI, wallet) as IUniswapV2Pair
-
-      await tokenA.transfer(pair.address, liquidity)
-      await tokenB.transfer(pair.address, liquidity)
-
-      await pair.mint(wallet.address)
-
-      return pair
-    }
-
     async function createPoolWETH9(token: TestERC20) {
       await weth9.deposit({ value: liquidity })
-      return createPool((weth9 as unknown) as TestERC20, token)
+      return createV2Pool((weth9 as unknown) as TestERC20, token)
     }
 
     beforeEach('create 0-1 and 1-2 pools', async () => {
-      const pair01 = await createPool(tokens[0], tokens[1])
-      const pair12 = await createPool(tokens[1], tokens[2])
+      const pair01 = await createV2Pool(tokens[0], tokens[1])
+      const pair12 = await createV2Pool(tokens[1], tokens[2])
       pairs = [pair01, pair12]
     })
 
@@ -1325,6 +1328,259 @@ describe('SwapRouter', function () {
             expect(traderAfter.token0).to.be.eq(traderBefore.token0.sub(3))
           })
         })
+      })
+    })
+  })
+
+  describe('swaps - v2 + v3', () => {
+    beforeEach('create 0-1 and 1-2 pools', async () => {
+      await createV3Pool(tokens[0].address, tokens[1].address)
+      await createV3Pool(tokens[1].address, tokens[2].address)
+    })
+
+    beforeEach('create 0-1 and 1-2 pools', async () => {
+      await createV2Pool(tokens[0], tokens[1])
+      await createV2Pool(tokens[1], tokens[2])
+    })
+
+    async function exactInputV3(
+      tokens: string[],
+      amountIn: number = 3,
+      amountOutMinimum: number = 1,
+      recipient: string,
+      hasAlreadyPaid: boolean,
+      skipAmountOutMinimumCheck: boolean = false
+    ): Promise<string[]> {
+      const params = {
+        path: encodePath(tokens, new Array(tokens.length - 1).fill(FeeAmount.MEDIUM)),
+        recipient,
+        amountIn,
+        amountOutMinimum,
+        hasAlreadyPaid,
+      }
+
+      const data = [router.interface.encodeFunctionData('exactInput', [params])]
+
+      if (!skipAmountOutMinimumCheck) {
+        // ensure that the swap fails if the limit is any tighter
+        const amountOut = await router.connect(trader).callStatic.exactInput(params)
+        expect(amountOut.toNumber()).to.be.eq(amountOutMinimum)
+      }
+
+      return data
+    }
+
+    async function exactOutputV3(
+      tokens: string[],
+      amountOut: number = 1,
+      amountInMaximum: number = 3,
+      recipient: string,
+      hasAlreadyPaid: boolean
+    ): Promise<string[]> {
+      const params = {
+        path: encodePath(tokens.slice().reverse(), new Array(tokens.length - 1).fill(FeeAmount.MEDIUM)),
+        recipient,
+        amountOut,
+        amountInMaximum,
+        hasAlreadyPaid,
+      }
+
+      const data = [router.interface.encodeFunctionData('exactOutput', [params])]
+
+      // ensure that the swap fails if the limit is any tighter
+      const amountIn = await router.connect(trader).callStatic.exactOutput(params)
+      expect(amountIn.toNumber()).to.be.eq(amountInMaximum)
+
+      return data
+    }
+
+    async function exactInputV2(
+      tokens: string[],
+      amountIn: number = 2,
+      amountOutMinimum: number = 1,
+      recipient: string,
+      hasAlreadyPaid: boolean,
+      skipAmountOutMinimumCheck: boolean = false
+    ): Promise<string[]> {
+      const params: [number, number, string[], string, boolean] = [
+        amountIn,
+        amountOutMinimum,
+        tokens,
+        recipient,
+        hasAlreadyPaid,
+      ]
+
+      const data = [router.interface.encodeFunctionData('swapExactTokensForTokens', params)]
+
+      if (!skipAmountOutMinimumCheck) {
+        // ensure that the swap fails if the limit is any tighter
+        const amountOut = await router.connect(trader).callStatic.swapExactTokensForTokens(...params)
+        expect(amountOut.toNumber()).to.be.eq(amountOutMinimum)
+      }
+
+      return data
+    }
+
+    async function exactOutputV2(
+      tokens: string[],
+      amountOut: number = 1,
+      amountInMaximum: number = 2,
+      recipient: string,
+      hasAlreadyPaid: boolean
+    ): Promise<string[]> {
+      const params: [number, number, string[], string, boolean] = [
+        amountOut,
+        amountInMaximum,
+        tokens,
+        recipient,
+        hasAlreadyPaid,
+      ]
+
+      const data = [router.interface.encodeFunctionData('swapTokensForExactTokens', params)]
+
+      // ensure that the swap fails if the limit is any tighter
+      const amountIn = await router.connect(trader).callStatic.swapTokensForExactTokens(...params)
+      expect(amountIn.toNumber()).to.be.eq(amountInMaximum)
+
+      return data
+    }
+
+    describe('simple split route', async () => {
+      it('sending directly', async () => {
+        const swapV3 = await exactInputV3(
+          tokens.slice(0, 2).map((token) => token.address),
+          3,
+          1,
+          MSG_SENDER,
+          false
+        )
+        const swapV2 = await exactInputV2(
+          tokens.slice(0, 2).map((token) => token.address),
+          2,
+          1,
+          MSG_SENDER,
+          false
+        )
+
+        const traderBefore = await getBalances(trader.address)
+
+        await router.connect(trader)['multicall(bytes[])']([...swapV3, ...swapV2])
+
+        const traderAfter = await getBalances(trader.address)
+        expect(traderAfter.token0).to.be.eq(traderBefore.token0.sub(5))
+        expect(traderAfter.token1).to.be.eq(traderBefore.token1.add(2))
+      })
+
+      it('sending to router and sweeping', async () => {
+        const swapV3 = await exactInputV3(
+          tokens.slice(0, 2).map((token) => token.address),
+          3,
+          1,
+          ADDRESS_THIS,
+          false
+        )
+        const swapV2 = await exactInputV2(
+          tokens.slice(0, 2).map((token) => token.address),
+          2,
+          1,
+          ADDRESS_THIS,
+          false
+        )
+
+        const sweep = encodeSweep(tokens[1].address, 2, trader.address)
+
+        const traderBefore = await getBalances(trader.address)
+
+        await router.connect(trader)['multicall(bytes[])']([...swapV3, ...swapV2, sweep])
+
+        const traderAfter = await getBalances(trader.address)
+        expect(traderAfter.token0).to.be.eq(traderBefore.token0.sub(5))
+        expect(traderAfter.token1).to.be.eq(traderBefore.token1.add(2))
+      })
+    })
+
+    describe('merging', () => {
+      // 0 ↘
+      // 0 → 1 → 2
+
+      // this merge trade is ultimately neither an exact input nor an exact output
+      // we need to start with exact output trades, as we need to know we're not going
+      // to end up with any amount of an intermediate token
+      it('exactOut x 2 + exactIn', async () => {
+        const swapV3 = await exactOutputV3(
+          tokens.slice(0, 2).map((token) => token.address),
+          1,
+          3,
+          ADDRESS_THIS,
+          false
+        )
+        const swapV2 = await exactOutputV2(
+          tokens.slice(0, 2).map((token) => token.address),
+          2,
+          3,
+          ADDRESS_THIS,
+          false
+        )
+
+        const mergeSwap = await exactInputV3(
+          tokens.slice(1, 3).map((token) => token.address),
+          3,
+          1,
+          MSG_SENDER,
+          true,
+          true
+        )
+
+        const traderBefore = await getBalances(trader.address)
+
+        await router.connect(trader)['multicall(bytes[])']([...swapV3, ...swapV2, ...mergeSwap])
+
+        const traderAfter = await getBalances(trader.address)
+        expect(traderAfter.token0).to.be.eq(traderBefore.token0.sub(6))
+        expect(traderAfter.token2).to.be.eq(traderBefore.token1.add(1))
+      })
+    })
+
+    describe('splitting', () => {
+      //       ↗ 2
+      // 0 → 1 → 2
+
+      // this split trade is ultimately neither an exact input nor an exact output
+      // we need to start with an exact output trade, as we need to know we're not going
+      // to end up with any amount of an intermediate token
+      it('exactOut + exactIn x 2', async () => {
+        const swapV3 = await exactOutputV3(
+          tokens.slice(0, 2).map((token) => token.address),
+          5,
+          7,
+          ADDRESS_THIS,
+          false
+        )
+
+        const splitSwapV2 = await exactInputV2(
+          tokens.slice(1, 3).map((token) => token.address),
+          2,
+          1,
+          MSG_SENDER,
+          true,
+          true
+        )
+        const splitSwapV3 = await exactInputV3(
+          tokens.slice(1, 3).map((token) => token.address),
+          3,
+          1,
+          MSG_SENDER,
+          true,
+          true
+        )
+
+        const traderBefore = await getBalances(trader.address)
+
+        await router.connect(trader)['multicall(bytes[])']([...swapV3, ...splitSwapV2, ...splitSwapV3])
+
+        const traderAfter = await getBalances(trader.address)
+        expect(traderAfter.token0).to.be.eq(traderBefore.token0.sub(7))
+        expect(traderAfter.token2).to.be.eq(traderBefore.token1.add(2))
       })
     })
   })

--- a/test/__snapshots__/SwapRouter.gas.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.gas.spec.ts.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175608`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175619`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `110754`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `110773`;
 
 exports[`SwapRouter gas tests #exactInput 0 -> 1 minimal 1`] = `98059`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127682`;
+exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127679`;
 
-exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `109079`;
+exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `109098`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `110225`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `110223`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `127153`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `127129`;
 
-exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `108550`;
+exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `108548`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169602`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169620`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `112000`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `112022`;
 
 exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128940`;
 
-exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `120003`;
+exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `119980`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `112190`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `112210`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `129130`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `129128`;
 
-exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `112980`;
+exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `112955`;

--- a/test/__snapshots__/SwapRouter.gas.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.gas.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175619`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175611`;
 
 exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `110773`;
 
@@ -16,7 +16,7 @@ exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `127129`;
 
 exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `108548`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169620`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169633`;
 
 exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `112022`;
 

--- a/test/__snapshots__/SwapRouter.gas.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.gas.spec.ts.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175387`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175619`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `110495`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `110773`;
 
 exports[`SwapRouter gas tests #exactInput 0 -> 1 minimal 1`] = `98059`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127423`;
+exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127679`;
 
-exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `108820`;
+exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `109098`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `109896`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `110223`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `126824`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `127129`;
 
-exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `108221`;
+exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `108548`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169283`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169620`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `111685`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `112022`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128625`;
+exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128940`;
 
-exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `119687`;
+exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `119980`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `111840`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `112210`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `128780`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `129128`;
 
-exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `112629`;
+exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `112955`;

--- a/test/__snapshots__/SwapRouter.gas.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.gas.spec.ts.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175619`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `175608`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `110773`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `110754`;
 
 exports[`SwapRouter gas tests #exactInput 0 -> 1 minimal 1`] = `98059`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127679`;
+exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127682`;
 
-exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `109098`;
+exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `109079`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `110223`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `110225`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `127129`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `127153`;
 
-exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `108548`;
+exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `108550`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169620`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169602`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `112022`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `112000`;
 
 exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128940`;
 
-exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `119980`;
+exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `120003`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `112210`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `112190`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `129128`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `129130`;
 
-exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `112955`;
+exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `112980`;

--- a/test/__snapshots__/SwapRouter.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter bytecode size 1`] = `19885`;
+exports[`SwapRouter bytecode size 1`] = `19884`;

--- a/test/__snapshots__/SwapRouter.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter bytecode size 1`] = `19885`;
+exports[`SwapRouter bytecode size 1`] = `20463`;

--- a/test/__snapshots__/SwapRouter.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter bytecode size 1`] = `20463`;
+exports[`SwapRouter bytecode size 1`] = `19885`;

--- a/test/__snapshots__/SwapRouter.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter bytecode size 1`] = `19659`;
+exports[`SwapRouter bytecode size 1`] = `19885`;


### PR DESCRIPTION
closes #8 

unlocks 2 use cases:

1. allows smart contracts to send tokens directly to the router to swap, obviating the need to manage approvals

2. unlocks (rudimentary) splitting and merging if intermediate tokens are sent to the router